### PR TITLE
Refactor chained syntax to be transactional

### DIFF
--- a/test.js
+++ b/test.js
@@ -277,5 +277,43 @@ describe('bind', function() {
 
     expect(newObj.a).to.be.eql({f: 2, q: 'q'})
   })
+
+  it('should return the bound object if no operations made', function() {
+    var obj = {};
+
+    expect(op(obj).value()).to.be.equal(obj)
+  })
+
+  it('should throw if an operation is attempted after `value` called', function (){
+    var transaction = op({
+      foo: 'bar',
+      fiz: [],
+      frob: {}
+    });
+
+    transaction.value();
+
+    expect(function (){
+      transaction.set('foo', 'baz')
+    }).to.throw()
+
+    expect(function (){
+      transaction.push('fiz', 'biz')
+    }).to.throw()
+
+    expect(function (){
+      transaction.insert('fiz', 'biz', 23)
+    }).to.throw()
+
+    expect(function (){
+      transaction.del('foo')
+    }).to.throw()
+
+    expect(function (){
+      transaction.assign('frob', {
+        nard: 23
+      })
+    }).to.throw()
+  })
 })
 


### PR DESCRIPTION
Because cloning objects and arrays is generally O(N) in the size of the number
of keys or elements, immutable operations are relatively expensive. In cases
where multiple operations are performed without any opportunity for others to
observe intermediate values, the obvious optimization is to clone only once (for
the first operation) and mutate afterward.

So, refactor our "bound" or chained syntax as follows:
- given a chain of operations on a source object, clone any descendants of that
  source object at most once
- throw on any attempt to perform an operation after `value` is called on chain

Achieving this necessitated some refactoring of the internal API. All operations
now take a source (`src`) and a destination (`dest`). When called "unchained",
the mutation methods receive a `null` source.

Fix #5 

---

I've deferred updating the README until this is ready to land. I can either push an update to the PR or amend the docs in a follow-on PR.