### PR TITLE
Fixed typo in chaining mode section

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ var newObj = immutable.assign(obj, 'a', { b: 'f', g: 'h' })
 //}
 
 //Chaining mode. value() at the end of the chain is used to retrieve the resulting object
-var newObj = immutable(obj).set(obj, 'a.b', 'f').del(obj, 'a.c.0').value()
+var newObj = immutable(obj).set('a.b', 'f').del('a.c.0').value()
 
 ```
 


### PR DESCRIPTION
I think this is a typo in the current chaining mode example. When I used that syntax it actually caused an error. 

BTW awesome library, solved a few of my gripes with seamless-immutable. 