### PR TITLE
Fixed del to allow deletion of falsy values in array

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,7 +180,7 @@
   api.del = function del (dest, src, path, value, at) {
     return changeImmutable(dest, src, path, function (clonedObj, finalPath) {
       if (Array.isArray(clonedObj)) {
-        if (clonedObj[finalPath]) {
+        if (clonedObj[finalPath] !== undefined) {
           clonedObj.splice(finalPath, 1)
         }
       } else {

--- a/test.js
+++ b/test.js
@@ -245,8 +245,8 @@ describe('del', function () {
     expect(op.del([23, 'yo', 42], 1)).to.deep.equal([23, 42])
   })
 
-  it('should delete falsy value', function() {
-    expect(op.del(['',false], 1)).to.deep.equal([''])
+  it('should delete falsy value', function () {
+    expect(op.del(['', false], 1)).to.deep.equal([''])
   })
 })
 

--- a/test.js
+++ b/test.js
@@ -244,6 +244,10 @@ describe('del', function () {
   it('should del at a numeric path', function () {
     expect(op.del([23, 'yo', 42], 1)).to.deep.equal([23, 42])
   })
+
+  it('should delete falsy value', function() {
+    expect(op.del(['',false], 1)).to.deep.equal([''])
+  })
 })
 
 describe('assign', function () {


### PR DESCRIPTION
Modified del API to allow deletion of falsy values in array item.
Before: `del([''], 0)).to.deep.equal([''])`
After: `del([''], 0)).to.deep.equal([])`