### PR TITLE
Fixed #18 (will improve code later)

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,9 @@
   var _hasOwnProperty = Object.prototype.hasOwnProperty
 
   function isEmpty (value) {
+    if (isNumber(value)) {
+      return false
+    }
     if (!value) {
       return true
     }
@@ -141,6 +144,9 @@
 
   var api = {}
   api.set = function set (dest, src, path, value) {
+    if (isEmpty(path)) {
+      return value
+    }
     return changeImmutable(dest, src, path, function (clonedObj, finalPath) {
       clonedObj[finalPath] = value
       return clonedObj
@@ -148,6 +154,9 @@
   }
 
   api.update = function update (dest, src, path, updater) {
+    if (isEmpty(path)) {
+      return updater(clone(src))
+    }
     return changeImmutable(dest, src, path, function (clonedObj, finalPath) {
       clonedObj[finalPath] = updater(clonedObj[finalPath])
       return clonedObj
@@ -156,6 +165,13 @@
 
   api.push = function push (dest, src, path /*, values */) {
     var values = Array.prototype.slice.call(arguments, 3)
+    if (isEmpty(path)) {
+      if (!isArray(src)) {
+        return values
+      } else {
+        return src.concat(values)
+      }
+    }
     return changeImmutable(dest, src, path, function (clonedObj, finalPath) {
       if (!isArray(clonedObj[finalPath])) {
         clonedObj[finalPath] = values
@@ -168,6 +184,14 @@
 
   api.insert = function insert (dest, src, path, value, at) {
     at = ~~at
+    if (isEmpty(path)) {
+      if (isEmpty(value)) {
+        return src
+      }
+      var first = src.slice(0, at)
+      first.push(value)
+      return first.concat(src.slice(at))
+    }
     return changeImmutable(dest, src, path, function (clonedObj, finalPath) {
       var arr = clonedObj[finalPath]
       if (!isArray(arr)) {
@@ -185,6 +209,9 @@
   }
 
   api.del = function del (dest, src, path, value, at) {
+    if (isEmpty(path)) {
+      return undefined
+    }
     return changeImmutable(dest, src, path, function (clonedObj, finalPath) {
       if (Array.isArray(clonedObj)) {
         if (clonedObj[finalPath] !== undefined) {
@@ -200,6 +227,12 @@
   }
 
   api.assign = function assign (dest, src, path, source) {
+    if (isEmpty(path)) {
+      if (isEmpty(source)) {
+        return src
+      }
+      return Object.assign({}, src, source)
+    }
     return changeImmutable(dest, src, path, function (clonedObj, finalPath) {
       source = Object(source)
       var target = clone(clonedObj[finalPath], true)

--- a/test.js
+++ b/test.js
@@ -63,10 +63,10 @@ describe('set', function () {
     expect(newObj.a).to.be.eql({b: [, {f: 'a'}]}) // eslint-disable-line no-sparse-arrays
   })
 
-  it('should return the original object if passed an empty path', function () {
+  it('should return the input value if passed an empty path', function () {
     var obj = {}
 
-    expect(op.set(obj, '', 'yo')).to.be.equal(obj)
+    expect(op.set(obj, '', 'yo')).to.be.equal('yo')
   })
 
   it('should set at a numeric path', function () {
@@ -167,11 +167,11 @@ describe('insert', function () {
   it('should throw if asked to insert into something other than an array',
     function () {
       expect(function () {
-        op.insert({ foo: 'bar' }, 'foo', 'baz')
+        op.insert({foo: 'bar'}, 'foo', 'baz')
       }).to.throw()
     })
 
-  it('should return the original object if passed an empty path', function () {
+  it('should return the original object if passed an empty path and empty value', function () {
     var obj = {}
 
     expect(op.insert(obj, '')).to.be.equal(obj)
@@ -213,10 +213,10 @@ describe('push', function () {
     expect(newObj.a).to.be.eql([[, ['b']]]) // eslint-disable-line no-sparse-arrays
   })
 
-  it('should return the original object if passed an empty path', function () {
+  it('should push into the cloned original object if passed an empty path', function () {
     var obj = {}
 
-    expect(op.push(obj, '', 'yo')).to.be.equal(obj)
+    expect(op.push(obj, '', 'yo')).to.deep.equal(['yo'])
   })
 
   it('should push at a numeric path', function () {
@@ -258,10 +258,10 @@ describe('del', function () {
     expect(newObj.a).to.be.eql([])
   })
 
-  it('should return the original object if passed an empty path', function () {
+  it('should return undefined if passed an empty path', function () {
     var obj = {}
 
-    expect(op.del(obj, '')).to.be.equal(obj)
+    expect(op.del(obj, '')).to.be.equal(undefined)
   })
 
   it('should del at a numeric path', function () {
@@ -284,7 +284,7 @@ describe('assign', function () {
       }
     }
 
-    var newObj = op.assign(obj, 'a', { b: 3 })
+    var newObj = op.assign(obj, 'a', {b: 3})
 
     expect(newObj).not.to.be.equal(obj)
     expect(newObj.a).not.to.be.equal(obj.a)
@@ -301,12 +301,12 @@ describe('assign', function () {
       }
     }
 
-    var newObj = op.assign(obj, 'a', { c: 2 })
+    var newObj = op.assign(obj, 'a', {c: 2})
 
     expect(newObj).not.to.be.equal(obj)
     expect(newObj.a).not.to.be.equal(obj.a)
     expect(obj.a).to.be.eql({b: 1})
-    expect(newObj.a).to.be.eql({ b: 1, c: 2 })
+    expect(newObj.a).to.be.eql({b: 1, c: 2})
   })
 
   it('should create intermediate objects', function () {
@@ -317,7 +317,7 @@ describe('assign', function () {
       }
     }
 
-    var newObj = op.assign(obj, 'a.b', { f: 'a' })
+    var newObj = op.assign(obj, 'a.b', {f: 'a'})
 
     expect(newObj).not.to.be.equal(obj)
     expect(newObj.a).not.to.be.equal(obj.a)
@@ -325,7 +325,7 @@ describe('assign', function () {
     expect(newObj.a).to.be.eql({b: {f: 'a'}})
   })
 
-  it('should return the original object if passed an empty path', function () {
+  it('should return the original object if passed an empty path and an empty value to assign', function () {
     var obj = {}
 
     expect(op.assign(obj, '', {})).to.be.equal(obj)


### PR DESCRIPTION
The fix is a bit hacky. To improve the code I'll need to change the recursive function and remove `finalPath` from the callback, but that breaks `del` when deleting array indices. Not sure what to do about that. Maybe it can check whether the last element in `path` is a number and handle that separately.

It passes the tests; I changed the tests where it was "returns the original object if passed an empty object".

There are also a few changes in `test.js`