### PR TITLE
Add link to types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "type": "git",
     "url": "git://github.com/mariocasciaro/object-path-immutable.git"
   },
+  "types": "./object-path-immutable.d.ts",
   "engines": {
     "node": ">=0.10.0"
   },


### PR DESCRIPTION
This adds a link to the types in the package.json so typescript can find the correct typings, since they're not named `index.d.ts`.