### PR TITLE
Allow TS to automatically detect type declaration

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "istanbul cover _mocha test.js --report html -- -R spec",
     "prepublish": "npm run test"
   },
+  "types": "./object-path-immutable.d.ts",
   "dependencies": {},
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
The "types" attribute allows TypeScript to automatically reference the included .d.ts.

See [Including declarations in your npm package](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package) for reference.