### PR TITLE
Change "path" parameter type to take `ReadonlyArray<string>` instead of `string[]`

### DIFF
--- a/object-path-immutable.d.ts
+++ b/object-path-immutable.d.ts
@@ -1,4 +1,4 @@
-type Path = string | string[]
+type Path = string | ReadonlyArray<string>;
 
 interface WrappedObject<T> {
     set(path?: Path, value?: any): WrappedObject<T>


### PR DESCRIPTION
This allows callers to pass a read-only version of an array path to set/push/...

This is okay because all these methods don't mutate the path parameter (only call the immutable `slice()` operation).

Further note that the `ReadonlyArray<T>` type is supported since TS 2.0 (2016).