### PR TITLE
Drop Node.js 4 from build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "4"
   - "6"
   - "8"
   - "10"


### PR DESCRIPTION
It's end-of-life since April 2018.