### PR TITLE
Update `assign` `source` parameter type to `any`

### DIFF
--- a/object-path-immutable.d.ts
+++ b/object-path-immutable.d.ts
@@ -4,7 +4,7 @@ interface WrappedObject<T> {
     set(path?: Path, value?: any): WrappedObject<T>
     push(path?: Path, value?: any): WrappedObject<T>
     del(path?: Path): WrappedObject<T>
-    assign(path?: Path, source?: T): WrappedObject<T>
+    assign(path?: Path, source?: any): WrappedObject<T>
     update(path?: Path, updater?: (formerValue: any) => any): WrappedObject<T>
     insert(path?: Path, value?: any, index?: number): WrappedObject<T>
     value(): T


### PR DESCRIPTION
`T` is the root type, this is usually not the source type used for assign as you generally are updating (assigning) a nested value, whos type is contained within, but not equal to T.

Fixes https://github.com/mariocasciaro/object-path-immutable/issues/42