### PR TITLE
Add merge() into WrappedObject and ObjectPathImmutable interface

### DIFF
--- a/object-path-immutable.d.ts
+++ b/object-path-immutable.d.ts
@@ -17,7 +17,7 @@ interface ObjectPathImmutable {
     push<T = object>(src: T, path?: Path, value?: any): T
     del<T = object>(src: T, path?: Path): T
     assign<T = object>(src: T, path?: Path, source?: T): T
-    merge<T = object>(src: T, path?: Path, source?: T): T
+    merge<T = object>(src: T, path?: Path, source?: any): T
     update<T = object>(src: T, path?: Path, updater?: (formerValue: any) => any): WrappedObject<T>
     insert<T = object>(src: T, path?: Path, value?: any, index?: number): T
 }

--- a/object-path-immutable.d.ts
+++ b/object-path-immutable.d.ts
@@ -5,6 +5,7 @@ interface WrappedObject<T> {
     push(path?: Path, value?: any): WrappedObject<T>
     del(path?: Path): WrappedObject<T>
     assign(path?: Path, source?: T): WrappedObject<T>
+    merge(path?: Path, source?: T): WrappedObject<T>
     update(path?: Path, updater?: (formerValue: any) => any): WrappedObject<T>
     insert(path?: Path, value?: any, index?: number): WrappedObject<T>
     value(): T
@@ -16,6 +17,7 @@ interface ObjectPathImmutable {
     push<T = object>(src: T, path?: Path, value?: any): T
     del<T = object>(src: T, path?: Path): T
     assign<T = object>(src: T, path?: Path, source?: T): T
+    merge<T = object>(src: T, path?: Path, source?: T): T
     update<T = object>(src: T, path?: Path, updater?: (formerValue: any) => any): WrappedObject<T>
     insert<T = object>(src: T, path?: Path, value?: any, index?: number): T
 }

--- a/object-path-immutable.d.ts
+++ b/object-path-immutable.d.ts
@@ -5,7 +5,7 @@ interface WrappedObject<T> {
     push(path?: Path, value?: any): WrappedObject<T>
     del(path?: Path): WrappedObject<T>
     assign(path?: Path, source?: T): WrappedObject<T>
-    merge(path?: Path, source?: T): WrappedObject<T>
+    merge(path?: Path, source?: any): WrappedObject<T>
     update(path?: Path, updater?: (formerValue: any) => any): WrappedObject<T>
     insert(path?: Path, value?: any, index?: number): WrappedObject<T>
     value(): T


### PR DESCRIPTION
Fixes: #45 
Adding the missing `merge` method into the interface declaration