### PR TITLE
Path can be an array of string | number

### DIFF
--- a/object-path-immutable.d.ts
+++ b/object-path-immutable.d.ts
@@ -1,4 +1,4 @@
-type Path = string | ReadonlyArray<string>;
+type Path = string | ReadonlyArray<number | string>;
 
 interface WrappedObject<T> {
     set(path?: Path, value?: any): WrappedObject<T>


### PR DESCRIPTION
As per the documentation `Note that if the path is specified as a string, numbers are automatically interpreted as array indexes` Path can be an array of strings and numbers