### PR TITLE
Update assign source parameter type to any in typescript declaration

### DIFF
--- a/object-path-immutable.d.ts
+++ b/object-path-immutable.d.ts
@@ -16,7 +16,7 @@ declare module 'object-path-immutable' {
     export function set<T = object>(src: T, path?: Path, value?: any): T
     export function push<T = object>(src: T, path?: Path, value?: any): T
     export function del<T = object>(src: T, path?: Path): T
-    export function assign<T = object>(src: T, path?: Path, source?: T): T
+    export function assign<T = object>(src: T, path?: Path, source?: any): T
     export function merge<T = object>(src: T, path?: Path, source?: any): T
     export function update<T = object>(src: T, path?: Path, updater?: (formerValue: any) => any): WrappedObject<T>
     export function insert<T = object>(src: T, path?: Path, value?: any, index?: number): T


### PR DESCRIPTION
As described in #42

> The `assign` method's `source` is incorrectly typed to `T` which is the root type, this is usually not the case as you generally are updating (assigning) a nested value, whos type is contained within, but not equal to T.
> 
> The correct type for the `source` parameter would be `any`

This also applies to the typescript declaration.