### PR TITLE
Fix incorrect paths in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ const newObj = immutable.set(obj, 'a.b', 'f')
 
 // obj !== newObj
 // obj.a !== newObj.a
-// obj.b !== newObj.b
+// obj.a.b !== newObj.a.b
 
 // However:
-// obj.c === newObj.c
+// obj.a.c === newObj.a.c
 ```
 
 Note that you can also chain the api's and call `value()` at the end to retrieve the resulting object.


### PR DESCRIPTION
First off, this library is awesome. Awesome.

It was exactly what I was looking for, and I was able to integrate it in just a few minutes. Perfect.

I noticed the docs were a tad off, no big deal, I presume it was just a slight oversight. Figured I'd send a PR with the fix, assuming I interpreted it correctly.

Thanks for making this.